### PR TITLE
Added Serbian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,10 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+# Mac stuff
+.DS_Store
+
+# other
+lit/

--- a/data/bib/allovera.bib
+++ b/data/bib/allovera.bib
@@ -121,6 +121,14 @@
   note   = {[Online; accessed 12-Nov-2019]}
 }
 
+@misc{Wiki:2020-serbian-phonology,
+  author = {{Wikipedia contributors}},
+  title  = {{Serbo-Croatian} Phonology --- {W}ikipedia{,} The Free Encyclopedia},
+  year   = {2020},
+  url    = {https://en.wikipedia.org/wiki/Serbo-Croatian_phonology},
+  note   = {[Online; accessed 19-May-2020]}
+}
+
 @misc{Wiki:2019-spanish-language,
   author = {{Wikipedia contributors}},
   title  = {{Spanish} Language in the {Americas} --- {W}ikipedia{,} The Free Encyclopedia},

--- a/data/json/srp.json
+++ b/data/json/srp.json
@@ -3,6 +3,7 @@
     "glottocodes": ["serb1264"],
     "primary src": "Wiki:2020-serbian-phonology",
     "secondary srcs": [],
+    "g2p": "custom",
     "mappings": [
         {
             "phone": "p",
@@ -89,6 +90,12 @@
             "articulatory description": "voiceless retroflex sibilant fricative"
         },
         {
+            "phone": "h",
+            "phoneme": "x",
+            "environment": "word initially",
+            "articulatory description": "voiceless glottal fricative"
+        },
+        {
             "phone": "x",
             "phoneme": "x",
             "environment": "elsewhere",
@@ -132,7 +139,7 @@
         },
         {
             "phone": "ɲ",
-            "phoneme": "n",
+            "phoneme": "ɲ",
             "environment": "elsewhere",
             "articulatory description": "voiced palatal nasal"
         },

--- a/data/json/srp.json
+++ b/data/json/srp.json
@@ -1,0 +1,200 @@
+{
+    "iso": "srp",
+    "glottocodes": ["serb1264"],
+    "primary src": "Wiki:2020-serbian-phonology",
+    "secondary srcs": [],
+    "mappings": [
+        {
+            "phone": "p",
+            "phoneme": "p",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless bilabial stop"
+        },
+        {
+            "phone": "t",
+            "phoneme": "t",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless dental stop"
+        },
+        {
+            "phone": "k",
+            "phoneme": "k",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless velar stop"
+        },
+        {
+            "phone": "b",
+            "phoneme": "b",
+            "environment": "elsewhere",
+            "articulatory description": "voiced bilabial stop"
+        },
+        {
+            "phone": "d",
+            "phoneme": "d",
+            "environment": "elsewhere",
+            "articulatory description": "voiced dental stop"
+        },
+        {
+            "phone": "g",
+            "phoneme": "ɡ",
+            "environment": "elsewhere",
+            "articulatory description": "voiced velar stop"
+        },
+        {
+            "phone": "t͡s",
+            "phoneme": "t͡s",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless dental affricate"
+        },
+        {
+            "phone": "t͡ʂ",
+            "phoneme": "t͡ʂ",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless retroflex sibilant affricate"
+        },
+        {
+            "phone": "t͡ɕ",
+            "phoneme": "t͡ɕ",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless alveolo-palatal sibilant affricate"
+        },
+        {
+            "phone": "d͡ʐ",
+            "phoneme": "d͡ʐ",
+            "environment": "elsewhere",
+            "articulatory description": "voiced retroflex sibilant affricate"
+        },
+        {
+            "phone": "d͡ʑ",
+            "phoneme": "d͡ʑ",
+            "environment": "elsewhere",
+            "articulatory description": "voiced alveolo-palatal sibilant affricate"
+        },
+        {
+            "phone": "f",
+            "phoneme": "f",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless labio-dental fricative"
+        },
+        {
+            "phone": "s",
+            "phoneme": "s",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless dental sibilant fricative"
+        },
+        {
+            "phone": "ʂ",
+            "phoneme": "ʂ",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless retroflex sibilant fricative"
+        },
+        {
+            "phone": "x",
+            "phoneme": "x",
+            "environment": "elsewhere",
+            "articulatory description": "voiceless velar fricative"
+        },
+        {
+            "phone": "v",
+            "phoneme": "v",
+            "environment": "elsewhere",
+            "articulatory description": "voiced labio-dental fricative"
+        },
+        {
+            "phone": "z",
+            "phoneme": "z",
+            "environment": "elsewhere",
+            "articulatory description": "voiced dental sibilant fricative"
+        },
+        {
+            "phone": "ʐ",
+            "phoneme": "ʐ",
+            "environment": "elsewhere",
+            "articulatory description": "voiced retroflex sibilant fricative"
+        },
+        {
+            "phone": "m",
+            "phoneme": "m",
+            "environment": "elsewhere",
+            "articulatory description": "voiced bilabial nasal"
+        },
+        {
+            "phone": "n",
+            "phoneme": "n",
+            "environment": "elsewhere",
+            "articulatory description": "voiced alveolar nasal"
+        },
+        {
+            "phone": "ŋ",
+            "phoneme": "n",
+            "environment": "before velar stops [k, g]",
+            "articulatory description": "voiced velar nasal"
+        },
+        {
+            "phone": "ɲ",
+            "phoneme": "n",
+            "environment": "elsewhere",
+            "articulatory description": "voiced palatal nasal"
+        },
+        {
+            "phone": "ɾ",
+            "phoneme": "r",
+            "environment": "intervocalically",
+            "articulatory description": "voiced alveolar flap"
+        },
+        {
+            "phone": "r",
+            "phoneme": "r",
+            "environment": "elsewhere",
+            "articulatory description": "voiced alveolar trill"
+        },
+        {
+            "phone": "j",
+            "phoneme": "j",
+            "environment": "elsewhere",
+            "articulatory description": "voiced palatal approximant"
+        },
+        {
+            "phone": "l",
+            "phoneme": "l",
+            "environment": "elsewhere",
+            "articulatory description": "voiced alveolar lateral approximant"
+        },
+        {
+            "phone": "ʎ",
+            "phoneme": "ʎ",
+            "environment": "elsewhere",
+            "articulatory description": "voiced palatal lateral approximant"
+        },
+        {
+            "phone": "i",
+            "phoneme": "i",
+            "environment": "elsewhere",
+            "articulatory description": "close front unrounded vowel"
+        },
+        {
+            "phone": "e",
+            "phoneme": "e",
+            "environment": "elsewhere",
+            "articulatory description": "mid front unrounded vowel"
+        },
+        {
+            "phone": "u",
+            "phoneme": "u",
+            "environment": "elsewhere",
+            "articulatory description": "close back rounded vowel"
+        },
+        {
+            "phone": "o",
+            "phoneme": "o",
+            "environment": "elsewhere",
+            "articulatory description": "mid back rounded vowel"
+        },
+        {
+            "phone": "a",
+            "phoneme": "a",
+            "environment": "elsewhere",
+            "articulatory description": "open central unrounded vowel"
+        }
+    ]
+}


### PR DESCRIPTION
Hi,

I've added support for the Serbian language. 

I've also taken the liberty to add another optional field in the mappings array: articulatory description, e.g.
```
{
    "phone": "ŋ",
    "phoneme": "n",
    "environment": "before velar stops [k, g]",
    "articulatory description": "voiced velar nasal"
}
```

I believe this could help differentiate phones whose broad IPA transcription is not specific enough. For example, phones such as [t, d, n] can be realized/described as dental, alveolar, or post-alveolar depending on the language or dialect, but the IPA alphabet often doesn't distinguish between these three places of articulation. 

If you think articulatory properties are useful to include, I'd be willing to add them for all the languages and phones in the database.


Best,
Marija